### PR TITLE
Force sdl2 to be version 2.3.0, as there is a bug with 2.2.0 and GHC 8.0

### DIFF
--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -25,7 +25,7 @@ library
                      , primitive              >= 0.6   && < 0.7
                      , reflex                 >= 0.5   && < 0.6
                      , ref-tf                 >= 0.4   && < 0.5
-                     , sdl2                   >= 2.2   && < 2.3
+                     , sdl2                   >= 2.3   && < 2.4
                      , stm                    >= 2.4   && < 2.5
   default-language:    Haskell2010
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.0
+resolver: lts-9.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -46,6 +46,7 @@ packages:
 extra-deps:
 - prim-uniq-0.1.0.1
 - ref-tf-0.4.0.1
+- sdl2-2.3.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
These are the simple changes I made to get `reflex-sdl2` working on Windows 10. There is more detail [here](https://www.reddit.com/r/haskellgamedev/comments/6wsvbi/example_reflexsdl2_app_using_sdl_renderer/dn2nm11/), but I'll copy it for reference:

I had previously installed `pkg-config` and `SDL2` with:

    stack exec -- pacman -Sy
    stack exec -- pacman -S mingw-w64-x86_64-pkg-config
    stack exec -- pacman -S mingw-w64-x86_64-SDL2

It might also be necessary to add the directory where these libraries and executables are installed to your PATH. For me, this location was at `/c/Users/kyle/AppData/Local/Programs/stack/x86_64-windows/msys2-20150512/mingw64/bin`.

After installing `SDL2` I modified `reflex-sdl2.cabal` to require `sdl2 >= 2.3.0`, which is necessary to overcome a bug detailed [here](https://github.com/haskell-game/sdl2/issues/139). Since `sdl2-2.3.0` is not in the resolver, I added it as an `extra-deps` to `stack.yaml` (I also bumped my resolver to `lts-9.4` since that's what I'm using on other projects).

After a `stack build` I was able to run the demo without a problem. 