### PR TITLE
No more user data, base and class.

### DIFF
--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -18,6 +18,8 @@ library
   ghc-options:         -Wall
   exposed-modules:     Reflex.SDL2
                      , Reflex.SDL2.Internal
+                     , Reflex.SDL2.Class
+                     , Reflex.SDL2.Base
   build-depends:       async                  >= 2.1   && < 2.2
                      , base                   >= 4.7   && < 5
                      , containers             >= 0.5   && < 0.6
@@ -38,6 +40,7 @@ executable reflex-sdl2-exe
   main-is:             Main.hs
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
+                     , mtl
                      , reflex-sdl2
   default-language:    Haskell2010
 

--- a/src/Reflex/SDL2/Base.hs
+++ b/src/Reflex/SDL2/Base.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+module Reflex.SDL2.Base
+  ( ReflexSDL2T (..)
+  , runReflexSDL2T
+  ) where
+
+
+import           Control.Monad.Exception  (MonadException)
+import           Control.Monad.IO.Class   (MonadIO)
+import           Control.Monad.Reader
+import           Reflex                   hiding (Additive)
+import           Reflex.Host.Class
+
+import           Reflex.SDL2.Class
+import           Reflex.SDL2.Internal
+
+
+------------------------------------------------------------------------------
+-- | Provides an implementation of the 'HasSDL2Events' type class.
+newtype ReflexSDL2T t (m :: * -> *) a =
+  ReflexSDL2T { unReflexSDL2T :: ReaderT (SystemEvents t) m a }
+
+
+runReflexSDL2T :: ReflexSDL2T t m a -> SystemEvents t -> m a
+runReflexSDL2T = runReaderT . unReflexSDL2T
+
+
+deriving instance (ReflexHost t, Functor m)        => Functor (ReflexSDL2T t m)
+deriving instance (ReflexHost t, Applicative m)    => Applicative (ReflexSDL2T t m)
+deriving instance (ReflexHost t, Monad m)          => Monad (ReflexSDL2T t m)
+deriving instance (ReflexHost t, MonadFix m)       => MonadFix (ReflexSDL2T t m)
+deriving instance (ReflexHost t, MonadIO m)        => MonadIO (ReflexSDL2T t m)
+deriving instance ReflexHost t                     => MonadTrans (ReflexSDL2T t)
+deriving instance (ReflexHost t, MonadException m) => MonadException (ReflexSDL2T t m)
+deriving instance (ReflexHost t, TriggerEvent t m) => TriggerEvent t (ReflexSDL2T t m)
+
+
+askSys :: Monad m => (SystemEvents t -> a) -> ReflexSDL2T t m a
+askSys = ReflexSDL2T . asks
+
+
+instance (ReflexHost t, Monad m) => HasSDL2Events t (ReflexSDL2T t m) where
+  getTicksEvent = askSys sysTicksEvent
+  getAnySDLEvent = askSys sysAnySDLEvent
+  getWindowShownEvent = askSys sysWindowShownEvent
+  getWindowHiddenEvent = askSys sysWindowHiddenEvent
+  getWindowExposedEvent = askSys sysWindowExposedEvent
+  getWindowMovedEvent = askSys sysWindowMovedEvent
+  getWindowResizedEvent = askSys sysWindowResizedEvent
+  getWindowSizeChangedEvent = askSys sysWindowSizeChangedEvent
+  getWindowMinimizedEvent = askSys sysWindowMinimizedEvent
+  getWindowMaximizedEvent = askSys sysWindowMaximizedEvent
+  getWindowRestoredEvent = askSys sysWindowRestoredEvent
+  getWindowGainedMouseFocusEvent = askSys sysWindowGainedMouseFocusEvent
+  getWindowLostMouseFocusEvent = askSys sysWindowLostMouseFocusEvent
+  getWindowGainedKeyboardFocusEvent = askSys sysWindowGainedKeyboardFocusEvent
+  getWindowLostKeyboardFocusEvent = askSys sysWindowLostKeyboardFocusEvent
+  getWindowClosedEvent = askSys sysWindowClosedEvent
+  getKeyboardEvent = askSys sysKeyboardEvent
+  getTextEditingEvent = askSys sysTextEditingEvent
+  getTextInputEvent = askSys sysTextInputEvent
+  getKeymapChangedEvent = askSys sysKeymapChangedEvent
+  getMouseMotionEvent = askSys sysMouseMotionEvent
+  getMouseButtonEvent = askSys sysMouseButtonEvent
+  getMouseWheelEvent = askSys sysMouseWheelEvent
+  getJoyAxisEvent = askSys sysJoyAxisEvent
+  getJoyBallEvent = askSys sysJoyBallEvent
+  getJoyHatEvent = askSys sysJoyHatEvent
+  getJoyButtonEvent = askSys sysJoyButtonEvent
+  getJoyDeviceEvent = askSys sysJoyDeviceEvent
+  getControllerAxisEvent = askSys sysControllerAxisEvent
+  getControllerButtonEvent = askSys sysControllerButtonEvent
+  getControllerDeviceEvent = askSys sysControllerDeviceEvent
+  getAudioDeviceEvent = askSys sysAudioDeviceEvent
+  getQuitEvent = askSys sysQuitEvent
+  getUserEvent = askSys sysUserEvent
+  getSysWMEvent = askSys sysSysWMEvent
+  getTouchFingerEvent = askSys sysTouchFingerEvent
+  getMultiGestureEvent = askSys sysMultiGestureEvent
+  getDollarGestureEvent = askSys sysDollarGestureEvent
+  getDropEvent = askSys sysDropEvent
+  getClipboardUpdateEvent = askSys sysClipboardUpdateEvent
+  getUnknownEvent = askSys sysUnknownEvent
+  getQuitVar = askSys sysQuitVar
+
+
+------------------------------------------------------------------------------
+-- | 'ReflexSDL2T' is an instance of 'PostBuild'.
+instance (Reflex t, PostBuild t m, ReflexHost t, Monad m) => PostBuild t (ReflexSDL2T t m) where
+  getPostBuild = lift getPostBuild
+
+
+------------------------------------------------------------------------------
+-- | 'ReflexSDL2T' is an instance of 'PerformEvent'.
+instance (ReflexHost t, PerformEvent t m) => PerformEvent t (ReflexSDL2T t m) where
+  type Performable (ReflexSDL2T t m) = ReflexSDL2T t (Performable m)
+  performEvent_ = ReflexSDL2T . performEvent_ . fmap unReflexSDL2T
+  performEvent  = ReflexSDL2T . performEvent  . fmap unReflexSDL2T
+
+
+------------------------------------------------------------------------------
+-- | 'ReflexSDL2T' is an instance of 'Adjustable'.
+instance ( Reflex t
+         , ReflexHost t
+         , Adjustable t m
+         , Monad m
+         ) => Adjustable t (ReflexSDL2T t m) where
+  runWithReplace ma evmb =
+    ReflexSDL2T $ runWithReplace (unReflexSDL2T ma) (unReflexSDL2T <$> evmb)
+  traverseDMapWithKeyWithAdjust kvma dMapKV = ReflexSDL2T .
+    traverseDMapWithKeyWithAdjust (\ka -> unReflexSDL2T . kvma ka) dMapKV
+  traverseDMapWithKeyWithAdjustWithMove kvma dMapKV = ReflexSDL2T .
+    traverseDMapWithKeyWithAdjustWithMove (\ka -> unReflexSDL2T . kvma ka) dMapKV
+  traverseIntMapWithKeyWithAdjust f im = ReflexSDL2T .
+    traverseIntMapWithKeyWithAdjust (\ka -> unReflexSDL2T . f ka) im
+
+
+------------------------------------------------------------------------------
+-- | 'ReflexSDL2T' is an instance of 'MonadHold'.
+instance ( ReflexHost t
+         , Applicative m
+         , Monad m
+         , MonadSample t m
+         ) => MonadSample t (ReflexSDL2T t m) where
+  sample = lift . sample
+
+
+------------------------------------------------------------------------------
+-- | 'ReflexSDL2T' is an instance of 'MonadHold'.
+instance (ReflexHost t, MonadHold t m) => MonadHold t (ReflexSDL2T t m) where
+  hold a = lift . hold a
+  holdDyn a = lift . holdDyn a
+  holdIncremental p = lift . holdIncremental p
+  buildDynamic ma = lift . buildDynamic ma
+  headE = lift . headE

--- a/src/Reflex/SDL2/Class.hs
+++ b/src/Reflex/SDL2/Class.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE UndecidableInstances   #-}
+module Reflex.SDL2.Class where
+
+
+import           Control.Concurrent   (MVar)
+import           Control.Monad.Reader (ReaderT)
+import           Control.Monad.Trans  (lift)
+import           Data.Word            (Word32)
+import           Reflex               (Event, Reflex)
+import           Reflex.DynamicWriter (DynamicWriterT)
+import           SDL                  hiding (Event)
+
+
+class (Reflex t, Monad m) => HasSDL2Events t m | m -> t where
+  getTicksEvent :: m (Event t Word32)
+  getAnySDLEvent :: m (Event t EventPayload)
+  getWindowShownEvent :: m (Event t WindowShownEventData)
+  getWindowHiddenEvent :: m (Event t WindowHiddenEventData)
+  getWindowExposedEvent :: m (Event t WindowExposedEventData)
+  getWindowMovedEvent :: m (Event t WindowMovedEventData)
+  getWindowResizedEvent :: m (Event t WindowResizedEventData)
+  getWindowSizeChangedEvent :: m (Event t WindowSizeChangedEventData)
+  getWindowMinimizedEvent :: m (Event t WindowMinimizedEventData)
+  getWindowMaximizedEvent :: m (Event t WindowMaximizedEventData)
+  getWindowRestoredEvent :: m (Event t WindowRestoredEventData)
+  getWindowGainedMouseFocusEvent :: m (Event t WindowGainedMouseFocusEventData)
+  getWindowLostMouseFocusEvent :: m (Event t WindowLostMouseFocusEventData)
+  getWindowGainedKeyboardFocusEvent :: m (Event t WindowGainedKeyboardFocusEventData)
+  getWindowLostKeyboardFocusEvent :: m (Event t WindowLostKeyboardFocusEventData)
+  getWindowClosedEvent :: m (Event t WindowClosedEventData)
+  getKeyboardEvent :: m (Event t KeyboardEventData)
+  getTextEditingEvent :: m (Event t TextEditingEventData)
+  getTextInputEvent :: m (Event t TextInputEventData)
+  getKeymapChangedEvent :: m (Event t ())
+  getMouseMotionEvent :: m (Event t MouseMotionEventData)
+  getMouseButtonEvent :: m (Event t MouseButtonEventData)
+  getMouseWheelEvent :: m (Event t MouseWheelEventData)
+  getJoyAxisEvent :: m (Event t JoyAxisEventData)
+  getJoyBallEvent :: m (Event t JoyBallEventData)
+  getJoyHatEvent :: m (Event t JoyHatEventData)
+  getJoyButtonEvent :: m (Event t JoyButtonEventData)
+  getJoyDeviceEvent :: m (Event t JoyDeviceEventData)
+  getControllerAxisEvent :: m (Event t ControllerAxisEventData)
+  getControllerButtonEvent :: m (Event t ControllerButtonEventData)
+  getControllerDeviceEvent :: m (Event t ControllerDeviceEventData)
+  getAudioDeviceEvent :: m (Event t AudioDeviceEventData)
+  getQuitEvent :: m (Event t ())
+  getUserEvent :: m (Event t UserEventData)
+  getSysWMEvent :: m (Event t SysWMEventData)
+  getTouchFingerEvent :: m (Event t TouchFingerEventData)
+  getMultiGestureEvent :: m (Event t MultiGestureEventData)
+  getDollarGestureEvent :: m (Event t DollarGestureEventData)
+  getDropEvent :: m (Event t DropEventData)
+  getClipboardUpdateEvent :: m (Event t ())
+  getUnknownEvent :: m (Event t UnknownEventData)
+  getQuitVar :: m (MVar ())
+
+
+instance HasSDL2Events t m => HasSDL2Events t (ReaderT r m) where
+  getTicksEvent = lift getTicksEvent
+  getAnySDLEvent = lift getAnySDLEvent
+  getWindowShownEvent = lift getWindowShownEvent
+  getWindowHiddenEvent = lift getWindowHiddenEvent
+  getWindowExposedEvent = lift getWindowExposedEvent
+  getWindowMovedEvent = lift getWindowMovedEvent
+  getWindowResizedEvent = lift getWindowResizedEvent
+  getWindowSizeChangedEvent = lift getWindowSizeChangedEvent
+  getWindowMinimizedEvent = lift getWindowMinimizedEvent
+  getWindowMaximizedEvent = lift getWindowMaximizedEvent
+  getWindowRestoredEvent = lift getWindowRestoredEvent
+  getWindowGainedMouseFocusEvent = lift getWindowGainedMouseFocusEvent
+  getWindowLostMouseFocusEvent = lift getWindowLostMouseFocusEvent
+  getWindowGainedKeyboardFocusEvent = lift getWindowGainedKeyboardFocusEvent
+  getWindowLostKeyboardFocusEvent = lift getWindowLostKeyboardFocusEvent
+  getWindowClosedEvent = lift getWindowClosedEvent
+  getKeyboardEvent = lift getKeyboardEvent
+  getTextEditingEvent = lift getTextEditingEvent
+  getTextInputEvent = lift getTextInputEvent
+  getKeymapChangedEvent = lift getKeymapChangedEvent
+  getMouseMotionEvent = lift getMouseMotionEvent
+  getMouseButtonEvent = lift getMouseButtonEvent
+  getMouseWheelEvent = lift getMouseWheelEvent
+  getJoyAxisEvent = lift getJoyAxisEvent
+  getJoyBallEvent = lift getJoyBallEvent
+  getJoyHatEvent = lift getJoyHatEvent
+  getJoyButtonEvent = lift getJoyButtonEvent
+  getJoyDeviceEvent = lift getJoyDeviceEvent
+  getControllerAxisEvent = lift getControllerAxisEvent
+  getControllerButtonEvent = lift getControllerButtonEvent
+  getControllerDeviceEvent = lift getControllerDeviceEvent
+  getAudioDeviceEvent = lift getAudioDeviceEvent
+  getQuitEvent = lift getQuitEvent
+  getUserEvent = lift getUserEvent
+  getSysWMEvent = lift getSysWMEvent
+  getTouchFingerEvent = lift getTouchFingerEvent
+  getMultiGestureEvent = lift getMultiGestureEvent
+  getDollarGestureEvent = lift getDollarGestureEvent
+  getDropEvent = lift getDropEvent
+  getClipboardUpdateEvent = lift getClipboardUpdateEvent
+  getUnknownEvent = lift getUnknownEvent
+  getQuitVar = lift getQuitVar
+
+
+instance HasSDL2Events t m => HasSDL2Events t (DynamicWriterT t w m) where
+  getTicksEvent = lift getTicksEvent
+  getAnySDLEvent = lift getAnySDLEvent
+  getWindowShownEvent = lift getWindowShownEvent
+  getWindowHiddenEvent = lift getWindowHiddenEvent
+  getWindowExposedEvent = lift getWindowExposedEvent
+  getWindowMovedEvent = lift getWindowMovedEvent
+  getWindowResizedEvent = lift getWindowResizedEvent
+  getWindowSizeChangedEvent = lift getWindowSizeChangedEvent
+  getWindowMinimizedEvent = lift getWindowMinimizedEvent
+  getWindowMaximizedEvent = lift getWindowMaximizedEvent
+  getWindowRestoredEvent = lift getWindowRestoredEvent
+  getWindowGainedMouseFocusEvent = lift getWindowGainedMouseFocusEvent
+  getWindowLostMouseFocusEvent = lift getWindowLostMouseFocusEvent
+  getWindowGainedKeyboardFocusEvent = lift getWindowGainedKeyboardFocusEvent
+  getWindowLostKeyboardFocusEvent = lift getWindowLostKeyboardFocusEvent
+  getWindowClosedEvent = lift getWindowClosedEvent
+  getKeyboardEvent = lift getKeyboardEvent
+  getTextEditingEvent = lift getTextEditingEvent
+  getTextInputEvent = lift getTextInputEvent
+  getKeymapChangedEvent = lift getKeymapChangedEvent
+  getMouseMotionEvent = lift getMouseMotionEvent
+  getMouseButtonEvent = lift getMouseButtonEvent
+  getMouseWheelEvent = lift getMouseWheelEvent
+  getJoyAxisEvent = lift getJoyAxisEvent
+  getJoyBallEvent = lift getJoyBallEvent
+  getJoyHatEvent = lift getJoyHatEvent
+  getJoyButtonEvent = lift getJoyButtonEvent
+  getJoyDeviceEvent = lift getJoyDeviceEvent
+  getControllerAxisEvent = lift getControllerAxisEvent
+  getControllerButtonEvent = lift getControllerButtonEvent
+  getControllerDeviceEvent = lift getControllerDeviceEvent
+  getAudioDeviceEvent = lift getAudioDeviceEvent
+  getQuitEvent = lift getQuitEvent
+  getUserEvent = lift getUserEvent
+  getSysWMEvent = lift getSysWMEvent
+  getTouchFingerEvent = lift getTouchFingerEvent
+  getMultiGestureEvent = lift getMultiGestureEvent
+  getDollarGestureEvent = lift getDollarGestureEvent
+  getDropEvent = lift getDropEvent
+  getClipboardUpdateEvent = lift getClipboardUpdateEvent
+  getUnknownEvent = lift getUnknownEvent
+  getQuitVar = lift getQuitVar

--- a/src/Reflex/SDL2/Internal.hs
+++ b/src/Reflex/SDL2/Internal.hs
@@ -6,7 +6,6 @@ module Reflex.SDL2.Internal where
 
 import           Control.Concurrent (MVar)
 import           Data.Word          (Word32)
-import           GHC.Conc           (TVar)
 import           Reflex             (Event)
 import           SDL                hiding (Event)
 
@@ -18,7 +17,7 @@ import           SDL                hiding (Event)
 -- An event for reflex's post network build event.
 --
 -- An event for each frame tick.
-data SystemEvents r t = SystemEvents
+data SystemEvents t = SystemEvents
   { sysPostBuildEvent                 :: Event t ()
   -- ^ Fired just after the FRP network is built.
   , sysTicksEvent                     :: Event t Word32
@@ -66,8 +65,6 @@ data SystemEvents r t = SystemEvents
   , sysDropEvent                      :: Event t DropEventData
   , sysClipboardUpdateEvent           :: Event t ()
   , sysUnknownEvent                   :: Event t UnknownEventData
-  , sysUserData                       :: r
-  -- ^ A slot to hold any custom user data.
   , sysQuitVar                        :: MVar ()
   -- ^ A var to sync quitting.
   }


### PR DESCRIPTION
Separates SDL2.hs into SDL2/Base.hs and SDL2/Class.hs which fits the reflex convention and helps with transformer stacks. Gets rid of user data (just use a reader like in the example).