### PR TITLE
Version bumps and haddock generation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ module Main where
 import           Control.Concurrent   (threadDelay)
 import           Control.Monad        (forM_, guard, void)
 import           Control.Monad.Reader (MonadReader (..), runReaderT)
+import           Reflex
 import           Reflex.SDL2
 
 

--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -1,5 +1,5 @@
 name:                reflex-sdl2
-version:             0.2.0.1
+version:             0.3.0.0
 synopsis:            SDL2 and reflex FRP
 description:         A minimal host for sdl2 based reflex apps.
 homepage:            https://github.com/schell/reflex-sdl2#readme

--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -20,17 +20,17 @@ library
                      , Reflex.SDL2.Internal
                      , Reflex.SDL2.Class
                      , Reflex.SDL2.Base
-  build-depends:       async                  >= 2.1   && < 2.2
+  build-depends:       async                  >= 2.1   && < 2.3
                      , base                   >= 4.7   && < 5
-                     , containers             >= 0.5   && < 0.6
+                     , containers             >= 0.5   && < 0.7
                      , dependent-sum          >= 0.4   && < 0.5
                      , exception-transformers >= 0.4   && < 0.5
                      , ref-tf                 >= 0.4   && < 0.5
                      , mtl                    >= 2.2   && < 2.3
                      , primitive              >= 0.6   && < 0.7
                      , reflex                 >= 0.5   && < 0.6
-                     , sdl2                   >= 2.3   && < 2.4
-                     , stm                    >= 2.4   && < 2.5
+                     , sdl2                   >= 2.3   && < 2.5
+                     , stm                    >= 2.4   && < 2.6
 
   default-language:    Haskell2010
 

--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -40,6 +40,7 @@ executable reflex-sdl2-exe
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , mtl
+                     , reflex                 >= 0.5   && < 0.6
                      , reflex-sdl2
   default-language:    Haskell2010
 

--- a/src/Reflex/SDL2.hs
+++ b/src/Reflex/SDL2.hs
@@ -69,7 +69,6 @@ import           GHC.Conc                 (atomically, newTVar, readTVar,
                                            readTVarIO, writeTVar)
 import           Reflex                   hiding (Additive)
 import           Reflex.Host.Class
-import           Reflex.Time              (tickLossyFrom')
 import           SDL                      hiding (Event, delay)
 
 import           Reflex.SDL2.Base

--- a/src/Reflex/SDL2.hs
+++ b/src/Reflex/SDL2.hs
@@ -47,7 +47,6 @@ module Reflex.SDL2
   , putDebugLnE
 
     -- * Re-exports
-  , module Reflex
   , module SDL
   , MonadIO
   , liftIO


### PR DESCRIPTION
In order to make this reflex-sdl2 build on nixpkgs I had to make the changes contained in this PR:

* Bumps of upper version bounds of dependencies
* Removed the re-export of Reflex, as it broke haddock generation due to some GHC bug.

I can understand if the last bullet is controversial.