### PR TITLE
feat: update to Reflex 6.4 and sdl 2.5.0.0

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -49,14 +49,14 @@ type Layer m = Performable m ()
 
 ----------------------------------------------------------------------
 -- | Commit a layer stack that changes over time.
-commitLayers :: (ReflexSDL2 t m, MonadDynamicWriter t [Layer m] m)
+commitLayers :: (ReflexSDL2 t m, DynamicWriter t [Layer m] m)
       => Dynamic t [Layer m] -> m ()
 commitLayers = tellDyn
 
 
 ----------------------------------------------------------------------
 -- | Commit one layer that changes over time.
-commitLayer :: (ReflexSDL2 t m, MonadDynamicWriter t [Layer m] m)
+commitLayer :: (ReflexSDL2 t m, DynamicWriter t [Layer m] m)
             => Dynamic t (Layer m) -> m ()
 commitLayer = tellDyn . fmap pure
 
@@ -83,7 +83,7 @@ buttonState isInside isDown
 
 
 button
-  :: (ReflexSDL2 t m, MonadDynamicWriter t [Layer m] m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, DynamicWriter t [Layer m] m, MonadReader Renderer m)
   => m (Event t ButtonState)
 button = do
   evMotionData <- getMouseMotionEvent
@@ -118,7 +118,7 @@ button = do
 
 
 guest
-  :: (ReflexSDL2 t m, MonadDynamicWriter t [Layer m] m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, DynamicWriter t [Layer m] m, MonadReader Renderer m)
   => m ()
 guest = do
   -- Print some stuff after the network is built.
@@ -249,10 +249,10 @@ main :: IO ()
 main = do
   initializeAll
   let ogl = defaultOpenGL{ glProfile = Core Debug 3 3 }
-      cfg = defaultWindow{ windowOpenGL      = Just ogl
-                         , windowResizable   = True
-                         , windowHighDPI     = False
-                         , windowInitialSize = V2 640 480
+      cfg = defaultWindow{ windowGraphicsContext = OpenGLContext ogl
+                         , windowResizable       = True
+                         , windowHighDPI         = False
+                         , windowInitialSize     = V2 640 480
                          }
   window <- createWindow "reflex-sdl2-exe" cfg
   void $ glCreateContext window

--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -23,13 +23,13 @@ library
   build-depends:       async                  >= 2.1   && < 2.3
                      , base                   >= 4.7   && < 5
                      , containers             >= 0.5   && < 0.7
-                     , dependent-sum          >= 0.4   && < 0.5
+                     , dependent-sum          >= 0.6   && < 0.7
                      , exception-transformers >= 0.4   && < 0.5
                      , ref-tf                 >= 0.4   && < 0.5
                      , mtl                    >= 2.2   && < 2.3
                      , primitive              >= 0.6   && < 0.7
-                     , reflex                 >= 0.5   && < 0.6
-                     , sdl2                   >= 2.3   && < 2.5
+                     , reflex                 >= 0.6   && < 0.7
+                     , sdl2                   >= 2.5   && < 2.6
                      , stm                    >= 2.4   && < 2.6
 
   default-language:    Haskell2010
@@ -40,7 +40,7 @@ executable reflex-sdl2-exe
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , mtl
-                     , reflex                 >= 0.5   && < 0.6
+                     , reflex                 >= 0.6   && < 0.7
                      , reflex-sdl2
   default-language:    Haskell2010
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.1
+resolver: lts-14.21
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,11 +40,14 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- git: https://github.com/reflex-frp/reflex
-  commit: 5d9c8a00f2eb832f109c870963182149b988062a
-- prim-uniq-0.1.0.1
-- ref-tf-0.4.0.1
-- sdl2-2.4.1.0
+- constraints-extras-0.3.0.2
+- dependent-map-0.3
+- dependent-sum-0.6.2.0
+- monoidal-containers-0.6.0.1
+- patch-0.0.3.1
+- ref-tf-0.4.0.2
+- reflex-0.6.4
+- witherable-0.3.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}
@@ -69,3 +72,6 @@ extra-package-dbs: []
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+nix:
+  packages: [ pkg-config, SDL2 ]


### PR DESCRIPTION
Hi,

I had to upgrade the dependencies' versions for a personal project. More specifically, this version is compatible with Reflex 6.4 and Haskell SDL2 2.5. Also added support for Nix through Stack.
It compiles fine and works with GHC 8.6.5. I haven't done any test on other versions. However, I'm sharing it, hoping it can prove useful!

Have a nice day!