### PR TITLE
Remove primitive to compile on GHC 8.8

### DIFF
--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -1,5 +1,5 @@
 name:                reflex-sdl2
-version:             0.3.0.0
+version:             0.3.0.1
 synopsis:            SDL2 and reflex FRP
 description:         A minimal host for sdl2 based reflex apps.
 homepage:            https://github.com/schell/reflex-sdl2#readme

--- a/reflex-sdl2.cabal
+++ b/reflex-sdl2.cabal
@@ -27,7 +27,6 @@ library
                      , exception-transformers >= 0.4   && < 0.5
                      , ref-tf                 >= 0.4   && < 0.5
                      , mtl                    >= 2.2   && < 2.3
-                     , primitive              >= 0.6   && < 0.7
                      , reflex                 >= 0.6   && < 0.7
                      , sdl2                   >= 2.5   && < 2.6
                      , stm                    >= 2.4   && < 2.6


### PR DESCRIPTION
In the course of trying to get things compiling on GHC 8.8.3 as per issue #20 I noticed primitive was unused so I removed it which got things compiling again.

Since no modules were being imported I assume there is no API change, so no major or minor version change is required by the PVP. I took the liberty of bumping the version patch number.